### PR TITLE
feat: initialize Apollo Client in root component

### DIFF
--- a/client/oss-hub/app/root.tsx
+++ b/client/oss-hub/app/root.tsx
@@ -1,0 +1,94 @@
+import {
+  isRouteErrorResponse,
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "react-router";
+
+import {
+  ApolloClient,
+  inMemoryCache,
+  ApolloProvider,
+  gql
+} from "@apollo/client";
+
+import type { Route } from "./+types/root";
+import "./app.css";
+
+// set up Apollo client
+const client = new ApolloClient({
+  uri: "http://192.168.49.2:31579/graphql",
+  cache: inMemoryCache(),
+});
+
+export const links: Route.LinksFunction = () => [
+  { rel: "preconnect", href: "https://fonts.googleapis.com" },
+  {
+    rel: "preconnect",
+    href: "https://fonts.gstatic.com",
+    crossOrigin: "anonymous",
+  },
+  {
+    rel: "stylesheet",
+    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
+  },
+];
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        {children}
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+
+export default function App() {
+  return (
+    <ApolloProvider client={client}>
+      <Layout>
+        <Outlet />
+      </Layout>
+    </ApolloProvider>
+  )
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  let message = "Oops!";
+  let details = "An unexpected error occurred.";
+  let stack: string | undefined;
+
+  if (isRouteErrorResponse(error)) {
+    message = error.status === 404 ? "404" : "Error";
+    details =
+      error.status === 404
+        ? "The requested page could not be found."
+        : error.statusText || details;
+  } else if (import.meta.env.DEV && error && error instanceof Error) {
+    details = error.message;
+    stack = error.stack;
+  }
+
+  return (
+    <main className="pt-16 p-4 container mx-auto">
+      <h1>{message}</h1>
+      <p>{details}</p>
+      {stack && (
+        <pre className="w-full p-4 overflow-x-auto">
+          <code>{stack}</code>
+        </pre>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
- Import Apollo Client dependencies.
- Set up Apollo Client with specified GraphQL endpoint and caching.
- Wrap the application in ApolloProvider to enable GraphQL queries throughout the app.
- Ensure Layout and routing are correctly nested within ApolloProvider.