### PR TITLE
feat(frontend): implement client-only Apollo Client provider

### DIFF
--- a/client/oss-hub/app/clientApolloProvider.tsx
+++ b/client/oss-hub/app/clientApolloProvider.tsx
@@ -1,0 +1,32 @@
+// ClientApolloProvider.tsx
+import React, { useEffect, useState } from "react";
+import { Outlet } from "react-router";
+
+export default function ClientApolloProvider() {
+  const [client, setClient] = useState<any>(null);
+
+  useEffect(() => {
+    // Dynamically import Apollo Client
+    import("@apollo/client").then((ApolloClientModule) => {
+      const { ApolloClient, ApolloProvider, InMemoryCache } = ApolloClientModule;
+      const apolloClient = new ApolloClient({
+        uri: "http://192.168.49.2:31579/graphql",
+        cache: new InMemoryCache({ assumeImmutableResults: true }),
+        ssrMode: false,
+      });
+      setClient({ ApolloProvider, client: apolloClient });
+    });
+  }, []);
+
+  if (!client) {
+    return <div>Loading Apollo Client...</div>;
+  }
+
+  const { ApolloProvider } = client;
+  return (
+    <ApolloProvider client={client.client}>
+      <Outlet />
+    </ApolloProvider>
+  );
+}
+

--- a/client/oss-hub/app/root.tsx
+++ b/client/oss-hub/app/root.tsx
@@ -6,22 +6,27 @@ import {
   Scripts,
   ScrollRestoration,
 } from "react-router";
+// import ApolloClientPackage from "@apollo/client";
+// const { ApolloProvider, ApolloClient, InMemoryCache } = ApolloClientPackage;
 
-import {
-  ApolloClient,
-  inMemoryCache,
-  ApolloProvider,
-  gql
-} from "@apollo/client";
+// import {
+//   ApolloClient,
+//   inMemoryCache,
+//   ApolloProvider,
+//   gql
+// } from "@apollo/client";
 
 import type { Route } from "./+types/root";
 import "./app.css";
 
 // set up Apollo client
-const client = new ApolloClient({
-  uri: "http://192.168.49.2:31579/graphql",
-  cache: inMemoryCache(),
-});
+// const client = new ApolloClient({
+//   uri: "http://192.168.49.2:31579/graphql",
+//   cache: InMemoryCache({
+//     assumeImmutableResults: true,
+//   }),
+//   ssrMode: false,
+// });
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -54,13 +59,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
+import ClientApolloProvider from "./clientApolloProvider.tsx"
+
 export default function App() {
   return (
-    <ApolloProvider client={client}>
-      <Layout>
-        <Outlet />
-      </Layout>
-    </ApolloProvider>
+    <Layout>
+      <ClientApolloProvider />
+    </Layout>
   )
 }
 


### PR DESCRIPTION
- Created a new component, ClientApolloProvider.tsx, that dynamically imports Apollo Client only on the client side.
- Replaced direct Apollo Client imports in root.tsx with the ClientApolloProvider to prevent SSR issues with Vite.
- Ensured that Apollo Client's configuration disables SSR mode and sets proper cache options.
- This change fixes the "Cannot set properties of undefined (setting 'assumeImmutableResults')" error.